### PR TITLE
Fix AuditorGroupAdmin for use with custom user model.

### DIFF
--- a/permissions_auditor/admin.py
+++ b/permissions_auditor/admin.py
@@ -171,7 +171,10 @@ class AuditorGroupAdmin(GroupAdmin):
     def users_display(self, obj):
         result = ''
         for user in obj.active_users:
-            url = reverse('admin:auth_user_change', args=(user.pk,))
+            url = reverse(
+                'admin:{}_{}_change'.format(user._meta.app_label, user._meta.model_name),
+                args=(user.pk,)
+            )
             result += '<a href="{}">{}</a><br/>'.format(url, user)
         return mark_safe(result)
 


### PR DESCRIPTION
As specified in [https://docs.djangoproject.com/en/dev/ref/contrib/admin/#admin-reverse-urls](https://docs.djangoproject.com/en/dev/ref/contrib/admin/#admin-reverse-urls), Django builds admin urls from the app_label and model_name fields. The AuditorGroupAdmin view uses hardcoded string "auth_user_change" in the reverse() call which breaks for Django instances using a custom user model.

Fix reverse() to use a string based on the app_label and model_name fields of the User object already retrieved with get_user_model().