### PR TITLE
Allow inherited permission mixins

### DIFF
--- a/docs/custom_processors.rst
+++ b/docs/custom_processors.rst
@@ -21,7 +21,7 @@ Other useful base classes:
 
 .. autoclass:: permissions_auditor.processors.base.BaseDecoratorProcessor
 
-.. autoclass:: permissions_auditor.processors.base.BaseFileredMixinProcessor
+.. autoclass:: permissions_auditor.processors.base.BaseFilteredMixinProcessor
     :members: class_filter, get_class_filter
 
 
@@ -55,9 +55,9 @@ Let's define our processor in `processors.py`.
 .. code-block:: python
     :caption: example_project/processors.py
 
-    from permissions_auditor.processors.base import BaseFileredMixinProcessor
+    from permissions_auditor.processors.base import BaseFilteredMixinProcessor
 
-    class BobRequiredMixinProcessor(BaseFileredMixinProcessor):
+    class BobRequiredMixinProcessor(BaseFilteredMixinProcessor):
         class_filter = 'example_project.views.BobRequiredMixin'
 
         def get_login_required(self, view):
@@ -117,9 +117,9 @@ We'll modify ``class_filter`` and ``get_docstring()`` from our old processor, an
 
 .. code-block:: python
 
-    from permissions_auditor.processors.base import BaseFileredMixinProcessor
+    from permissions_auditor.processors.base import BaseFilteredMixinProcessor
 
-    class FirstNameRequiredMixinProcessor(BaseFileredMixinProcessor):
+    class FirstNameRequiredMixinProcessor(BaseFilteredMixinProcessor):
         class_filter = 'example_project.views.FirstNameRequiredMixin'
 
         def get_permission_required(self, view):

--- a/permissions_auditor/processors/auth_mixins.py
+++ b/permissions_auditor/processors/auth_mixins.py
@@ -4,10 +4,10 @@ import inspect
 
 from django.conf import ImproperlyConfigured
 
-from .base import BaseFileredMixinProcessor
+from .base import BaseFilteredMixinProcessor
 
 
-class PermissionRequiredMixinProcessor(BaseFileredMixinProcessor):
+class PermissionRequiredMixinProcessor(BaseFilteredMixinProcessor):
     """
     Processes views that inherit from
     ``django.contrib.auth.mixins.PermissionRequiredMixin``.
@@ -41,7 +41,7 @@ class PermissionRequiredMixinProcessor(BaseFileredMixinProcessor):
         return docstring
 
 
-class LoginRequiredMixinProcessor(BaseFileredMixinProcessor):
+class LoginRequiredMixinProcessor(BaseFilteredMixinProcessor):
     """
     Processes views that inherit from
     ``django.contrib.auth.mixins.LoginRequiredMixin``.
@@ -53,7 +53,7 @@ class LoginRequiredMixinProcessor(BaseFileredMixinProcessor):
         return True
 
 
-class UserPassesTestMixinProcessor(BaseFileredMixinProcessor):
+class UserPassesTestMixinProcessor(BaseFilteredMixinProcessor):
     """
     Processes views that inherit from
     ``django.contrib.auth.mixins.UserPassesTestMixin``.

--- a/permissions_auditor/processors/auth_mixins.py
+++ b/permissions_auditor/processors/auth_mixins.py
@@ -9,7 +9,7 @@ from .base import BaseFileredMixinProcessor
 
 class PermissionRequiredMixinProcessor(BaseFileredMixinProcessor):
     """
-    Processes views that directly inherit from
+    Processes views that inherit from
     ``django.contrib.auth.mixins.PermissionRequiredMixin``.
 
     .. hint::
@@ -43,7 +43,7 @@ class PermissionRequiredMixinProcessor(BaseFileredMixinProcessor):
 
 class LoginRequiredMixinProcessor(BaseFileredMixinProcessor):
     """
-    Processes views that directly inherit from
+    Processes views that inherit from
     ``django.contrib.auth.mixins.LoginRequiredMixin``.
     """
 
@@ -55,7 +55,7 @@ class LoginRequiredMixinProcessor(BaseFileredMixinProcessor):
 
 class UserPassesTestMixinProcessor(BaseFileredMixinProcessor):
     """
-    Processes views that directly inherit from
+    Processes views that inherit from
     ``django.contrib.auth.mixins.UserPassesTestMixin``.
 
     .. hint::

--- a/permissions_auditor/processors/base.py
+++ b/permissions_auditor/processors/base.py
@@ -167,10 +167,10 @@ class BaseFileredMixinProcessor(BaseCBVProcessor):
         if not super().can_process(view):
             return False
 
-        view_bases = [cls.__module__ + '.' + cls.__name__ for cls in view.__bases__]
+        view_parents = [cls.__module__ + '.' + cls.__name__ for cls in view.__mro__]
 
         for cls_filter in self.get_class_filter():
-            if cls_filter in view_bases:
+            if cls_filter in view_parents:
                 return True
 
         return False

--- a/permissions_auditor/processors/base.py
+++ b/permissions_auditor/processors/base.py
@@ -153,7 +153,7 @@ class BaseDecoratorProcessor(BaseProcessor):
         return False
 
 
-class BaseFileredMixinProcessor(BaseCBVProcessor):
+class BaseFilteredMixinProcessor(BaseCBVProcessor):
     """
     Base class for parsing mixins on class based views.
     Set ``class_filter`` to filter the class names the processor applies to.

--- a/permissions_auditor/tests/fixtures/views.py
+++ b/permissions_auditor/tests/fixtures/views.py
@@ -21,6 +21,10 @@ class LoginRequiredView(LoginRequiredMixin, View):
     pass
 
 
+class InheritedLoginRequiredView(LoginRequiredView):
+    pass
+
+
 class LoginRequiredMethodDecoratorView(View):
     @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
@@ -29,6 +33,10 @@ class LoginRequiredMethodDecoratorView(View):
 
 class PermissionRequiredView(PermissionRequiredMixin, View):
     permission_required = 'tests.test_perm'
+
+
+class InheritedPermissionRequiredView(PermissionRequiredView):
+    pass
 
 
 class PermissionRequiredMultiView(PermissionRequiredMixin, View):
@@ -70,6 +78,11 @@ class StaffMemberRequiredMethodDecoratorView(View):
 
 
 class UserPassesTestView(UserPassesTestMixin, View):
+    def test_func(self):
+        return True
+
+
+class InheritedUserPassesTestView(UserPassesTestView):
     def test_func(self):
         return True
 

--- a/permissions_auditor/tests/test_auth_mixin_processors.py
+++ b/permissions_auditor/tests/test_auth_mixin_processors.py
@@ -36,6 +36,9 @@ class TestLoginRequiredMixinProcessor(MixinProcessorTestCaseMixin, ProcessorTest
     def test_cb_loginrequiredview(self):
         self.assertCanProcessView(views.LoginRequiredView, **self.expected_results)
 
+    def test_cb_inheritedloginrequiredview(self):
+        self.assertCanProcessView(views.InheritedLoginRequiredView, **self.expected_results)
+
 
 class TestPermissionRequiredMixinProcessor(MixinProcessorTestCaseMixin, ProcessorTestCase):
 
@@ -52,6 +55,12 @@ class TestPermissionRequiredMixinProcessor(MixinProcessorTestCaseMixin, Processo
     def test_cb_permissionsrequiredview(self):
         self.assertCanProcessView(
             views.PermissionRequiredView,
+            permissions=['tests.test_perm'], login_required=True, docstring=None
+        )
+
+    def test_cb_inherit_permissionsrequiredview(self):
+        self.assertCanProcessView(
+            views.InheritedPermissionRequiredView,
             permissions=['tests.test_perm'], login_required=True, docstring=None
         )
 
@@ -109,6 +118,12 @@ class TestUserPassesTestMixinProcessor(MixinProcessorTestCaseMixin, ProcessorTes
     def test_cb_userpassestestview(self):
         self.assertCanProcessView(
             views.UserPassesTestView,
+            permissions=[], login_required=None, docstring='Custom (no docstring found)'
+        )
+
+    def test_cb_inheriteduserpassestestview(self):
+        self.assertCanProcessView(
+            views.InheritedUserPassesTestView,
             permissions=[], login_required=None, docstring='Custom (no docstring found)'
         )
 

--- a/permissions_auditor/tests/test_base_processors.py
+++ b/permissions_auditor/tests/test_base_processors.py
@@ -39,7 +39,7 @@ class BaseCBVProcessorTest(ProcessorTestCase):
 
 class BaseFilteredMixinProcessorTest(ProcessorTestCase):
     def setUp(self):
-        self.processor = base.BaseFileredMixinProcessor()
+        self.processor = base.BaseFilteredMixinProcessor()
 
     def test_no_class_filter_raises_exception(self):
         with self.assertRaises(ImproperlyConfigured):


### PR DESCRIPTION
Changes the `can_process` code to look through an object's entire method resolution (uses [`__mro__`](https://docs.python.org/3/library/stdtypes.html#class.__mro__) instead of `__bases__`).

Also fixed a misspelling, but that's in a completely separate commit so let me know if you'd rather me exclude those changes and/or open a separate PR.